### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -17,7 +17,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_scrape extends DokuWiki_Action_Plugin {
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
 
 #       $controller->register_hook('INDEXER_PAGE_ADD', 'FIXME', $this, 'handle_indexer_page_add');
 

--- a/syntax.php
+++ b/syntax.php
@@ -37,7 +37,7 @@ class syntax_plugin_scrape extends DokuWiki_Syntax_Plugin {
     }
 
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match, 9, -2);
         list($url, $title) = explode('|', $match, 2);
         list($url, $query) = explode(' ', $url, 2);
@@ -62,7 +62,7 @@ class syntax_plugin_scrape extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    public function render($mode, &$R, $data) {
+    public function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'xhtml') return false;
 
         // support interwiki shortcuts


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.